### PR TITLE
Add Launch Octave button

### DIFF
--- a/layouts/_partials/docs/header.html
+++ b/layouts/_partials/docs/header.html
@@ -7,6 +7,7 @@
 
   <div class="flex align-center">
     <button id="open-terminal" class="book-btn" style="margin-right:8px;">Terminal</button>
+    <a href="{{ .Site.Params.terminalURL }}" target="_blank" class="book-btn" style="margin-right:8px;">Launch Octave</a>
     <label for="toc-control">
       {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}
       <img src="{{ "svg/toc.svg" | relURL }}" class="book-icon" alt="Table of Contents" />


### PR DESCRIPTION
## Summary
- add a `Launch Octave` link next to the terminal button so users can open the container in a new tab

## Testing
- `apt-get update`
- `apt-get install -y hugo`
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_684f6369b87c832187c9e2c26a4f40be