### PR TITLE
Add terminal button in posts

### DIFF
--- a/content/posts/docker-terminal.md
+++ b/content/posts/docker-terminal.md
@@ -36,3 +36,7 @@ docker run --rm -p 8080:8080 my-octave-term
 ```
 
 Luego simplemente pulsa el botón y se mostrará la terminal en cualquier página.
+
+Si quieres probarla directamente desde aquí, utiliza el siguiente botón:
+
+<button class="book-btn open-terminal">Abrir terminal</button>

--- a/layouts/_partials/docs/header.html
+++ b/layouts/_partials/docs/header.html
@@ -6,7 +6,7 @@
   <h3>{{ partial "docs/title" . }}</h3>
 
   <div class="flex align-center">
-    <button id="open-terminal" class="book-btn" style="margin-right:8px;">Terminal</button>
+    <button class="book-btn open-terminal" style="margin-right:8px;">Terminal</button>
     <a href="{{ .Site.Params.terminalURL }}" target="_blank" class="book-btn" style="margin-right:8px;">Launch Octave</a>
     <label for="toc-control">
       {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}

--- a/static/js/terminal.js
+++ b/static/js/terminal.js
@@ -1,10 +1,12 @@
 document.addEventListener('DOMContentLoaded', function () {
-  var openBtn = document.getElementById('open-terminal');
+  var openBtns = document.querySelectorAll('.open-terminal');
   var modal = document.getElementById('terminal-modal');
   var closeBtn = document.getElementById('close-terminal');
-  if (openBtn && modal && closeBtn) {
-    openBtn.addEventListener('click', function () {
-      modal.style.display = 'block';
+  if (modal && closeBtn) {
+    openBtns.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        modal.style.display = 'block';
+      });
     });
     closeBtn.addEventListener('click', function () {
       modal.style.display = 'none';


### PR DESCRIPTION
## Summary
- allow multiple elements to trigger the terminal modal
- switch header button to class `open-terminal`
- embed a terminal button in the Docker terminal post

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_684f699c325c83219b3fd5486dcde79b