### PR TITLE
Improve terminal modal dragging

### DIFF
--- a/layouts/_partials/docs/inject/body.html
+++ b/layouts/_partials/docs/inject/body.html
@@ -1,2 +1,3 @@
 {{ partial "terminal-modal" . }}
+<link rel="stylesheet" href="{{ "css/terminal.css" | relURL }}">
 <script src="{{ "js/terminal.js" | relURL }}"></script>

--- a/layouts/_partials/terminal-modal.html
+++ b/layouts/_partials/terminal-modal.html
@@ -1,5 +1,5 @@
 <div id="terminal-modal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.75);z-index:1000;">
-  <div style="position:absolute;top:5%;left:5%;width:90%;height:90%;background:#fff;box-shadow:0 0 10px rgba(0,0,0,0.5);">
+  <div class="terminal-window" style="position:absolute;top:5%;left:5%;width:90%;height:90%;background:#fff;box-shadow:0 0 10px rgba(0,0,0,0.5);">
     <button id="close-terminal" class="book-btn" style="float:right;margin:8px;">Cerrar</button>
     <iframe src="{{ .Site.Params.terminalURL }}" width="100%" height="90%" frameborder="0"></iframe>
   </div>

--- a/static/css/terminal.css
+++ b/static/css/terminal.css
@@ -1,0 +1,6 @@
+.no-select {
+  user-select: none;
+}
+.terminal-window {
+  cursor: move;
+}

--- a/static/js/terminal.js
+++ b/static/js/terminal.js
@@ -2,6 +2,10 @@ document.addEventListener('DOMContentLoaded', function () {
   var openBtns = document.querySelectorAll('.open-terminal');
   var modal = document.getElementById('terminal-modal');
   var closeBtn = document.getElementById('close-terminal');
+  var windowDiv = modal ? modal.querySelector('.terminal-window') : null;
+  var isDragging = false;
+  var offsetX = 0;
+  var offsetY = 0;
   if (modal && closeBtn) {
     openBtns.forEach(function (btn) {
       btn.addEventListener('click', function () {
@@ -11,5 +15,30 @@ document.addEventListener('DOMContentLoaded', function () {
     closeBtn.addEventListener('click', function () {
       modal.style.display = 'none';
     });
+
+    if (windowDiv) {
+      windowDiv.addEventListener('pointerdown', function (e) {
+        if (e.target === closeBtn) return;
+        isDragging = true;
+        offsetX = e.clientX - windowDiv.offsetLeft;
+        offsetY = e.clientY - windowDiv.offsetTop;
+        document.body.classList.add('no-select');
+        window.addEventListener('pointermove', onDrag);
+        window.addEventListener('pointerup', endDrag);
+      });
+    }
+  }
+
+  function onDrag(e) {
+    if (!isDragging) return;
+    windowDiv.style.left = e.clientX - offsetX + 'px';
+    windowDiv.style.top = e.clientY - offsetY + 'px';
+  }
+
+  function endDrag() {
+    isDragging = false;
+    document.body.classList.remove('no-select');
+    window.removeEventListener('pointermove', onDrag);
+    window.removeEventListener('pointerup', endDrag);
   }
 });


### PR DESCRIPTION
## Summary
- allow dragging the terminal modal window
- disable text selection while dragging
- load new CSS for dragging styles

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e5d4a5c8832185bd5be7b0f32dee