### PR TITLE
Show Octave terminal per-post

### DIFF
--- a/content/posts/docker-terminal.md
+++ b/content/posts/docker-terminal.md
@@ -2,6 +2,7 @@
 title: "Terminal Docker"
 date: 2025-06-15T00:00:00-04:00
 draft: false
+exercise: Longitud_Tuberia.m
 ---
 
 En esta guía veremos cómo exponer una terminal que se ejecuta dentro de un contenedor Docker y cómo incrustarla en una página generada con Hugo.
@@ -37,6 +38,4 @@ docker run --rm -p 8080:8080 my-octave-term
 
 Luego simplemente pulsa el botón y se mostrará la terminal en cualquier página.
 
-Si quieres probarla directamente desde aquí, utiliza el siguiente botón:
-
-<button class="book-btn open-terminal">Abrir terminal</button>
+Si quieres probarla directamente desde aquí, utiliza el botón que aparece al principio del post.

--- a/hugo.toml
+++ b/hugo.toml
@@ -5,4 +5,4 @@ theme = 'book'
 draft = 'false'
 
 [params]
-terminalURL = 'http://localhost:8080'
+terminalURL = '$HUGO_TERMINAL_URL'

--- a/layouts/_partials/docs/header.html
+++ b/layouts/_partials/docs/header.html
@@ -6,7 +6,6 @@
   <h3>{{ partial "docs/title" . }}</h3>
 
   <div class="flex align-center">
-    <button class="book-btn open-terminal" style="margin-right:8px;">Terminal</button>
     <a href="{{ .Site.Params.terminalURL }}" target="_blank" class="book-btn" style="margin-right:8px;">Launch Octave</a>
     <label for="toc-control">
       {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}

--- a/layouts/_partials/docs/inject/body.html
+++ b/layouts/_partials/docs/inject/body.html
@@ -1,3 +1,1 @@
-{{ partial "terminal-modal" . }}
-<link rel="stylesheet" href="{{ "css/terminal.css" | relURL }}">
-<script src="{{ "js/terminal.js" | relURL }}"></script>
+

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<article class="markdown book-post">
+  <h1>
+    {{ partial "docs/title.html" . }}
+  </h1>
+  {{ partial "docs/post-meta" . }}
+
+  {{ with .Params.exercise }}
+  <p><a href="{{ $.Site.Params.terminalURL }}/?arg={{ . }}" class="book-btn" onclick="window.open(this.href, '_blank', 'width=1000,height=600'); return false;">Abrir terminal</a></p>
+  {{ end }}
+
+  <div class="book-post-content">
+    {{- .Content -}}
+  </div>
+</article>
+{{ end }}
+
+{{ define "toc" }}
+  {{ partial "docs/toc" . }}
+{{ end }}


### PR DESCRIPTION
## Summary
- remove old terminal modal logic
- use an environment variable for `terminalURL`
- show an **Abrir terminal** button in posts with `exercise` front-matter
- example front-matter added to `docker-terminal.md`

## Testing
- `hugo` *(fails: partial `docs/html-head` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686998343d9c8321afdc2d03a25fd25c